### PR TITLE
Added predictions functionality

### DIFF
--- a/src/Constants.java
+++ b/src/Constants.java
@@ -1,6 +1,7 @@
 
 public final class Constants {
 	public static final int PORT = 6667;
+	public static final String BROADCASTER = "<YOUR USERNAME HERE>"; // username of the broadcaster
 	public static final String NICK = "<TWITCH NAME HERE>"; // username of Twitch account to connect
 	public static final String LASTFM_USER = "<LAST.FM USERNAME HERE>";   // username of last.fm user to grab song data from
 	public static final String CHANNEL = "<DESIRED TWITCH CHANNEL HERE>";	   // desired twitch channel to join (note: multiple supported)

--- a/src/Predictions.java
+++ b/src/Predictions.java
@@ -1,76 +1,163 @@
-import java.util.TreeMap;
+import java.awt.Toolkit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.pircbotx.Channel;
 import org.pircbotx.hooks.ListenerAdapter;
 import org.pircbotx.hooks.events.MessageEvent;
 
-import com.google.common.collect.ImmutableSortedSet;
-
 
 public class Predictions extends ListenerAdapter {
+  Toolkit toolkit;
+  Timer timer;
 
-	int count = 0; 
-	private String result = "";
-	boolean activePreds = false;
-	boolean isMod = false;
-	TreeMap<String, PredsUserData> currentPredInfo = new TreeMap<String, PredsUserData>();
+  // Threaded timer
+  class EndTask extends TimerTask {
+    private Channel channel;
+    public EndTask(Channel c) {
+      channel = c;
+    }
+    public void run() {
+      channel.send().message("Prediction entries are now closed!  Good luck!");
+      predsEnabled = false;
+      waitingForFinalInput = true;
+    }
+  }
+    
+  // When predictions are accepted
+  boolean predsEnabled = false;
+  // When the game is waiting for final input from broadcaster
+  boolean waitingForFinalInput = false;
 
-	public void onMessage(MessageEvent event) {
-		
-		if(event.getUser().getNick().equals("raysfire")) {
-			isMod = true;
-		}
-		
-		if(event.getMessage().toLowerCase().equals("!preds_on") && isMod) {
-			activePreds = true;
-			event.getChannel().send().message("Predictions are enabled! Please send your prediction in the following format: '!pred x:y', where x is desired kills, and y is desired deaths.");
-		}
+  // Command that starts the game
+  public static final String commandKey = "!preds";
+  
+  // Store predictions in a hash map
+  Map<String, Double> userPredictions = new HashMap<>();
+  
+  // Pattern to match the following: minutes-seconds-subseconds, seconds-subseconds, whole numbers
+  Pattern predictionPattern = Pattern.compile("(?:(?<minutes>\\d{1,2}):)?(?<seconds>\\d{1,2})(?:[:.](?<subseconds>\\d{1,3}))?");
 
-		if(event.getMessage().toLowerCase().equals("!preds_off") && isMod) {
-			activePreds = false;
-			event.getChannel().send().message("Predictions are now closed for the current contest.");
+  // Helper to send messages to the server
+  public void sendMessage(MessageEvent event, String message) {
+    event.getChannel().send().message(message);
+  }
+  
+  // Match against the regex pattern, and convert all formats into seconds.subseconds format
+  public Double getPrediction(String message) {
+    Matcher m = predictionPattern.matcher(message);
+  
+    if (m.matches()) {
+      String minutes = m.group("minutes");
+      String seconds = m.group("seconds");
+      String subseconds = m.group("subseconds");
 
-		}
+      if(subseconds == null && minutes != null) {
+        subseconds = seconds;
+        seconds = minutes;
+        minutes = null;
+      }
+      if (minutes == null)
+         minutes = "0";
+      if (subseconds == null)
+         subseconds = "0";
 
-		if(event.getMessage().toLowerCase().contains("!pred") && activePreds) {
-			String[] predInfo = event.getMessage().toLowerCase().split("[^0-9]+");
-			PredsUserData currUser = new PredsUserData(predInfo);
-			currentPredInfo.put(event.getUser().getNick(), currUser);
-		}
-		
-		if(event.getMessage().toLowerCase().contains("!checkpred") && isMod) {
-			String[] finalInfo = event.getMessage().toLowerCase().split("[^0-9]+");
-			String rawKills = finalInfo[1];
-			String rawDeaths = finalInfo[2];
-			
-			int kills = Integer.parseInt(rawKills);
-			int deaths = Integer.parseInt(rawDeaths);
-			
-			for(String n : currentPredInfo.keySet()) {
-				if(currentPredInfo.get(n).getKills() == kills && currentPredInfo.get(n).getDeaths() == deaths) {
-					event.getChannel().send().message(n + " has won the pred contest!");
-				}
-			}
-			
-			//reset for next pred contest
-			count = 0;
-			result = "";
-			activePreds = false;
-			currentPredInfo.clear();
-			isMod = false;
-		}
+      return Integer.parseInt(minutes) * 60 + Integer.parseInt(seconds) + Double.parseDouble("." + subseconds);
+    }
+    
+    return null;
+  }
+  
+  // Start the game if we receive the correct command from the broadcaster, and a game isn't already running
+  public boolean shouldStartPreds(MessageEvent event) {
+    if (event.getUser().getNick().equals(Constants.BROADCASTER) && event.getMessage().toLowerCase().startsWith(commandKey) && !predsEnabled) {
+      predsEnabled = true;
+      waitingForFinalInput = false;
+      return true;
+    }
+    return false;
+  }
+  
+  // Start the timer to stop receiving predictions
+  public void endPreds(int seconds, MessageEvent event) {
+    toolkit = Toolkit.getDefaultToolkit();
+    timer = new Timer();
+    timer.schedule(new EndTask(event.getChannel()), seconds * 1000);
+  }
+  
+  // Determine and send message with the winning prediction and user
+  public void displayWinner(Channel channel, Double finalTime) {
+    double difference = Double.MAX_VALUE;
+    List<String> closestUsers = new ArrayList<String>();
+    double closestPrediction = 0;
 
-		if(event.getMessage().toLowerCase().contains("!listpreds") && currentPredInfo.size() > 0) {
-			result += "Current users with predictions: ";
-			for(String n : currentPredInfo.keySet()) {
-				result += n;
-				count++;
-				if(count != currentPredInfo.size()) {
-					result += ", ";
-				}
-			}
-			event.getChannel().send().message(result);
-			result = "";
-		}
-	}
+    for(Map.Entry<String, Double> entry : userPredictions.entrySet()) {
+      double predictionDifference = Math.abs(finalTime - entry.getValue());
+      
+      if (predictionDifference <= difference) {
+        closestPrediction = entry.getValue();
+        
+        if (predictionDifference == difference) {
+          closestUsers.add(entry.getKey());
+        } else {
+          closestUsers.clear();
+          closestUsers.add(entry.getKey());
+        }
+        difference = predictionDifference;
+      }
+    }
+    
+    String closestPredictionMessage;
+    
+    if (closestPrediction > 60) {
+      int minutes = (int) Math.floor(closestPrediction / 60);
+      double seconds = closestPrediction - minutes * 60;
+      closestPredictionMessage = String.format("%1$02d:%2$.2f", minutes, seconds);
+    } else {
+      closestPredictionMessage = Double.toString(closestPrediction);
+    }
+
+    
+    channel.send().message("Congratulations to " + closestUsers + " with a prediction of " + closestPredictionMessage + "!");
+    
+    // Reset predictions
+    userPredictions.clear();
+    waitingForFinalInput = false;
+  }
+
+  public void onMessage(MessageEvent event) {
+    String message = event.getMessage();
+    
+    if (shouldStartPreds(event)) {
+      String[] params = message.split(" ");
+      
+      int predsDuration = 10;
+      
+      if (params.length > 1) {
+        predsDuration = Integer.parseInt(params[1]);
+      }
+      
+      sendMessage(event, "Enter your predictions now!  You have " + predsDuration + " seconds!");
+      endPreds(predsDuration, event);
+    } else if (predsEnabled) {
+      Double prediction = getPrediction(event.getMessage());
+      
+      if (prediction != null) {
+        userPredictions.put(event.getUser().getNick(), prediction);
+      }
+    } else if (waitingForFinalInput && event.getUser().getNick().equals(Constants.BROADCASTER)) {
+      Double result = getPrediction(event.getMessage());
+      
+      if (result != null) {
+        displayWinner(event.getChannel(), result);
+      } 
+    }
+    
+  }
 }


### PR DESCRIPTION
#### Usage
1. Enter your username in the new `BROADCASTER` constant.
2. Use command `!preds` to begin predictions game.  Optional second parameter for duration (seconds) to accept predictions (default of 10 seconds otherwise): `!preds 30`
3. All messages in the format of: minutes-seconds-subseconds, seconds-subseconds, whole numbers will go into the predictions list.  Examples: 12:34:56, 2.5, 5
4. When prediction window is closed, the bot will wait for the broadcaster to input the final time.  Use the format explained above to input the final time/result.
5.  User with closest prediction will be displayed as winner.  Will show multiple winners if there are ties.
#### Screenshot

![](http://i.imgur.com/Km54XYk.png)
#### Other notes
- Using a more recent version of pircxbot when I was testing, which required converting the deprecated `setServer` method into `addServer` and `setServerPassword`.  I don't think you need to make this change yourself unless you also upgrade your library.
- A possible good enhancement for the bot in general would be to utilize command line args, or ENV variables for some of the constants.
